### PR TITLE
Fix use of recordings-path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
           const apiKey = "${{ inputs.api-key }}";
           const issue_number = "${{ inputs.issue-number }}";
           let recordings = ${{ inputs.recordings || 'null' }};
-          const recordingsPath = `${{ inputs.recordings-path || null }}`;
+          const recordingsPath = `${{ inputs.recordings-path || '' }}`;
           const summaryMessage =  `${{ inputs.summary-message }}`;
           const testRunMessage =  `${{ inputs.test-run-message }}`;
           const testRunId = "${{ inputs.test-run-id }}";

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
           const apiKey = "${{ inputs.api-key }}";
           const issue_number = "${{ inputs.issue-number }}";
           let recordings = ${{ inputs.recordings || 'null' }};
-          const recordingsPath = ${{ inputs.recordings-path || 'null' }};
+          const recordingsPath = `${{ inputs.recordings-path || null }}`;
           const summaryMessage =  `${{ inputs.summary-message }}`;
           const testRunMessage =  `${{ inputs.test-run-message }}`;
           const testRunId = "${{ inputs.test-run-id }}";


### PR DESCRIPTION
The value from the other step has to be wrapped in quotes because it is supposed to come in as a raw string.

This wasn't noticed in the devtools integration because there is another bug in how the value was generated that need to be fixed.