### PR TITLE
Update `actions/github-script`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: 'Comment PR'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       if: ${{ always() }}
       with:
         result-encoding: string


### PR DESCRIPTION
I noticed warnings in one of our CI runs:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This should fix it